### PR TITLE
correct typo in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "includes/auth"]
-	path = includes/auth
+[submodule "lib/auth"]
+	path = lib/auth
 	url = https://github.com/jumbojett/OpenID-Connect-PHP.git


### PR DESCRIPTION
Hi, When I try to follow your new turorial, the recursive cloning abort due to a little error (I think he is one) in `.gitmodules` .

`git clone --recursive https://github.com/jumbojett/Wordpress-OpenID-Connect-Login.git` run well after this.
